### PR TITLE
Support for pretty xml dump added to dumps function.

### DIFF
--- a/simplexml/core.py
+++ b/simplexml/core.py
@@ -115,7 +115,7 @@ def dict_from_element(element, dic):
 
     return dic
 
-def dumps(data):
+def dumps(data, pretty=False):
     
     data_items = [(key, values) for key, values in data.items()]
     rootName, rootValue = data_items[0]
@@ -130,6 +130,8 @@ def dumps(data):
     
     element_from_dict(document, rootNode,  rootValue)
 
+    if pretty == True:
+        return document.toprettyxml()
     return document.toxml()
 
 def loads(data):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,3 +108,10 @@ def test_can_dumps_with_first_node_list():
     response = simplexml.dumps(sometag)
 
     assert '<someTags><someTag><nome>Should Be Nome</nome></someTag><someTag><nome>Should Be Nome</nome></someTag></someTags>' in response
+
+def test_can_dumps_with_pretty():
+
+    sometag = {'someTags': [{'someTag': {'nome': 'Should Be Nome'}}, {'someTag': {'nome': 'Should Be Nome'}}]}
+    response = simplexml.dumps(sometag, pretty=True)
+
+    assert '\n<someTags>\n\t<someTag>\n\t\t<nome>Should Be Nome</nome>\n\t</someTag>\n\t<someTag>\n\t\t<nome>Should Be Nome</nome>\n\t</someTag>\n</someTags>\n' in response


### PR DESCRIPTION
If argument "pretty=True" given to dumps(), then out is based on doc.toprettyxml().
By default pretty argument is False to have backwars compatible function API.