### PR TITLE
Fix single node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 2.7
     - 3.2
     - 3.3
+    - 3.8
 install:
     - pip install -r requirements.txt --use-mirrors
 script:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,3 +108,22 @@ def test_can_dumps_with_first_node_list():
     response = simplexml.dumps(sometag)
 
     assert '<someTags><someTag><nome>Should Be Nome</nome></someTag><someTag><nome>Should Be Nome</nome></someTag></someTags>' in response
+
+def test_can_dumps_with_single_simple_node():
+    sometag = {'someTag': 'Should be Name'}
+    response = simplexml.dumps(sometag)
+
+    assert '<someTag>Should be Name</someTag>' in response
+
+def test_can_dumps_with_root_node_containing_text_node():
+    sometag = {'someTag': {'_attrs': {'id': '1'}, '_value': 'Should be value'}}
+    response = simplexml.dumps(sometag)
+    
+    assert '<someTag id="1">Should be value</someTag>' in response
+
+def test_repeated_calls_to_dumps_preserves_dict_attrs():
+    sometag = {'someTag': {'_attrs': {'id': '1'}, '_value': 'Should be value'}}
+    response1 = simplexml.dumps(sometag)
+    response2 = simplexml.dumps(sometag)
+    
+    assert '<someTag id="1">Should be value</someTag>' in response2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33
+envlist = py26,py27,py33,py38
 [testenv]
 deps=
     nose==1.1.2


### PR DESCRIPTION
Ran into a few issues when using this very handy module:
1. When dumping very simple dicts like {'a', 'b'} you get an error, in fact there's no way to get an output of \<a\>b\</a\> even using _value keys. 
2. When dumping a dict, the code strips the _attrs keys from the underlying dict, so dumping the same dict more than once gives different results (no attributes on subsequent dumps).

These minor amendments should address both of these issues - I've included test cases for both. 

Many thanks.